### PR TITLE
[ISSUE-3] Enforce pre-commit Python hook languages

### DIFF
--- a/.agents/skills/create-lint/references/pre_commit_conventions.md
+++ b/.agents/skills/create-lint/references/pre_commit_conventions.md
@@ -27,6 +27,8 @@ Decide `language` first:
 - You may fall back to `language: script` only when the hook has zero third-party dependencies, the execution environment is controlled, and `python3` is guaranteed.
 - A `.py` filename is not a reason to choose `language: script`; the deciding factor is environment ownership, not file extension.
 - If consumers may use a non-Python repository or machines without Python preinstalled, `language: python` is mandatory.
+- Before switching a shared hook repository to `language: python`, make the repository installable for `pip install .` with `pyproject.toml` or `setup.py`.
+- In `agent-guardrails`, `.pre-commit-hooks.yaml` is linted to reject Python entrypoints that do not declare `language: python`.
 
 When adding or migrating a hook, use this order of decisions:
 
@@ -135,13 +137,14 @@ If a hook needs project-level semantics, such as "check backend runtime only, no
 2. Decide `language` first: shared Python hooks default to `python`, and `script` is allowed only for explicit exceptions
 3. Implement the script as a file-list consumer that reads only `sys.argv[1:]`
 4. If `language: script` is chosen, set the executable bit with `chmod +x <script>` and `git update-index --chmod=+x <script>`
-5. Add or update the hook definition in `.pre-commit-hooks.yaml`, including `language`, `types`, `types_or`, and `exclude`
-6. If the script needs same-directory imports, use `sys.path.insert(0, str(Path(__file__).parent))`
-7. Run positive validation: an in-scope violation must fail
-8. Run negative validation: excluded paths, test directories, or non-target file types must not be reported
-9. If `language: python` is used, validate that pre-commit can create the runtime environment successfully
-10. Prefer `pre-commit try-repo /home/fanrui/code/agent-guardrails <hook-id> --all-files` for realistic hook validation
-11. Only commit, push, or update the consumer repository `rev` when the user explicitly asks
+5. Path-based script entrypoints must be executable even when `language: python` is used
+6. Add or update the hook definition in `.pre-commit-hooks.yaml`, including `language`, `types`, `types_or`, and `exclude`
+7. If the script needs same-directory imports, use `sys.path.insert(0, str(Path(__file__).parent))`
+8. Run positive validation: an in-scope violation must fail
+9. Run negative validation: excluded paths, test directories, or non-target file types must not be reported
+10. If `language: python` is used, validate that pre-commit can create the runtime environment successfully
+11. Prefer `pre-commit try-repo /home/fanrui/code/agent-guardrails <hook-id> --all-files` for realistic hook validation
+12. Only commit, push, or update the consumer repository `rev` when the user explicitly asks
 
 ## Extra Requirements For Migrating Legacy Hooks
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,5 +15,12 @@ repos:
       - id: lint-no-chinese
         name: No Chinese characters in source
         entry: general/lint_no_chinese.py
-        language: script
+        language: python
         exclude: '(^|/)(\.venv|node_modules|dist|build|__pycache__|requirements)(/|$)|(^|/)(AGENTS|CLAUDE)\.md$'
+      - id: lint-pre-commit-hook-languages
+        name: Pre-commit hook language selection
+        entry: general/lint_pre_commit_hook_languages.py
+        language: python
+        types: [yaml]
+        files: ^\.pre-commit-(?:config|hooks)\.yaml$
+        exclude: '^$'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,19 +1,27 @@
 - id: lint-shell-portability
   name: Shell portability (no GNU-only syntax)
-  language: script
+  language: python
   entry: shell/lint_shell_portability.py
   types: [shell]
   exclude: '(^|/)(\.venv|node_modules|dist|build|mobile/android|frontend/dist)/'
 
 - id: lint-no-chinese
   name: No Chinese characters in source
-  language: script
+  language: python
   entry: general/lint_no_chinese.py
   exclude: '(^|/)(\.venv|node_modules|dist|build|__pycache__|requirements)(/|$)|(^|/)(AGENTS|CLAUDE)\.md$'
 
 - id: lint-backend-bare-dict
   name: No bare dict in backend Python
-  language: script
+  language: python
   entry: python/lint_backend_bare_dict.py
   types: [python]
   exclude: '(^|/)(tests?|\.venv|__pycache__|dist|build)/'
+
+- id: lint-pre-commit-hook-languages
+  name: Pre-commit hook language selection
+  language: python
+  entry: general/lint_pre_commit_hook_languages.py
+  types: [yaml]
+  files: ^\.pre-commit-(?:config|hooks)\.yaml$
+  exclude: '^$'

--- a/general/lint_pre_commit_hook_languages.py
+++ b/general/lint_pre_commit_hook_languages.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Validate Python entrypoints in pre-commit YAML files use language: python."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+HOOK_START_PATTERN = re.compile(r"^(?P<indent>\s*)- id:\s*(?P<hook_id>.+?)\s*$")
+FIELD_PATTERN = re.compile(r"^(?P<indent>\s+)(?P<key>entry|language):\s*(?P<value>.+?)\s*$")
+LIST_ITEM_PATTERN = re.compile(r"^(?P<indent>\s*)-\s")
+
+
+def normalize_scalar(raw_value: str) -> str:
+    """Return a plain scalar string without inline comments or matching quotes."""
+    value = raw_value.split(" #", maxsplit=1)[0].strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def check_file(path: Path) -> list[str]:
+    """Return language-selection violations for a pre-commit hook manifest."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    violations: list[str] = []
+
+    current_hook_id: str | None = None
+    current_hook_line = 0
+    current_hook_indent = -1
+    current_entry: str | None = None
+    current_entry_line = 0
+    current_language: str | None = None
+    current_language_line = 0
+
+    def flush_current_hook() -> None:
+        nonlocal current_hook_id
+        nonlocal current_hook_line
+        nonlocal current_hook_indent
+        nonlocal current_entry
+        nonlocal current_entry_line
+        nonlocal current_language
+        nonlocal current_language_line
+
+        if current_hook_id is None or current_entry is None or not current_entry.endswith(".py"):
+            current_hook_id = None
+            current_hook_line = 0
+            current_hook_indent = -1
+            current_entry = None
+            current_entry_line = 0
+            current_language = None
+            current_language_line = 0
+            return
+
+        if current_language != "python":
+            report_line = current_language_line or current_entry_line or current_hook_line
+            actual_language = current_language or "<missing>"
+            violations.append(
+                f"{path}:{report_line} hook '{current_hook_id}' uses Python entry "
+                f"'{current_entry}' but language is '{actual_language}'. "
+                "Python entrypoints in this repository must use 'language: python'."
+            )
+
+        current_hook_id = None
+        current_hook_line = 0
+        current_hook_indent = -1
+        current_entry = None
+        current_entry_line = 0
+        current_language = None
+        current_language_line = 0
+
+    for line_number, line in enumerate(lines, start=1):
+        hook_match = HOOK_START_PATTERN.match(line)
+        if hook_match is not None:
+            flush_current_hook()
+            current_hook_id = normalize_scalar(hook_match.group("hook_id"))
+            current_hook_line = line_number
+            current_hook_indent = len(hook_match.group("indent"))
+            continue
+
+        list_item_match = LIST_ITEM_PATTERN.match(line)
+        if (
+            current_hook_id is not None
+            and list_item_match is not None
+            and len(list_item_match.group("indent")) <= current_hook_indent
+        ):
+            flush_current_hook()
+
+        field_match = FIELD_PATTERN.match(line)
+        if current_hook_id is None or field_match is None:
+            continue
+
+        field_indent = len(field_match.group("indent"))
+        if field_indent <= current_hook_indent:
+            continue
+
+        key = field_match.group("key")
+        value = normalize_scalar(field_match.group("value"))
+        if key == "entry":
+            current_entry = value
+            current_entry_line = line_number
+        elif key == "language":
+            current_language = value
+            current_language_line = line_number
+
+    flush_current_hook()
+    return violations
+
+
+def main() -> int:
+    files = [Path(file_name) for file_name in sys.argv[1:]]
+    if not files:
+        return 0
+
+    violations: list[str] = []
+    for path in files:
+        violations.extend(check_file(path))
+
+    if violations:
+        print("Pre-commit hook language lint failed:")
+        for violation in violations:
+            print(f"  - {violation}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agent-guardrails"
+version = "0.1.0"
+description = "Shared pre-commit hooks for repository guardrails."
+readme = "README.md"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+
+[tool.setuptools]
+packages = []
+py-modules = []


### PR DESCRIPTION
## Summary

- add a dedicated lint to reject Python hook entrypoints that are declared with the wrong pre-commit language
- enforce the rule in both `.pre-commit-hooks.yaml` and `.pre-commit-config.yaml`
- switch the existing Python hook entrypoints from `language: script` to `language: python`
- add minimal packaging metadata so `language: python` hooks can be installed by pre-commit
- document the packaging and executable-entrypoint constraints in the local hook creation conventions

## Validation

- reproduced the failure with `pre-commit try-repo` before the fix and confirmed the new lint reported the incorrect language declarations in both manifests
- reran `pre-commit try-repo` after the fix and confirmed the targeted manifest files passed
- verified a non-target YAML file is skipped by the new hook scope
- ran `pre-commit run --all-files`

close #3
