### PR TITLE
[ISSUE-5] Add GitHub CI and hook integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: main
+
+on:
+  push:
+    branches: [main, test-me-*]
+    tags: '*'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  main-windows:
+    uses: asottile/workflows/.github/workflows/tox.yml@v1.8.1
+    with:
+      env: '["py311"]'
+      os: windows-latest
+  main-linux:
+    uses: asottile/workflows/.github/workflows/tox.yml@v1.8.1
+    with:
+      env: '["py311", "py312", "py313", "pre-commit"]'
+      os: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,12 @@ repos:
     hooks:
       - id: lint-no-chinese
         name: No Chinese characters in source
-        entry: general/lint_no_chinese.py
+        entry: python -m agent_guardrails.general.lint_no_chinese
         language: python
         exclude: '(^|/)(\.venv|node_modules|dist|build|__pycache__|requirements)(/|$)|(^|/)(AGENTS|CLAUDE)\.md$'
       - id: lint-pre-commit-hook-languages
         name: Pre-commit hook language selection
-        entry: general/lint_pre_commit_hook_languages.py
+        entry: python -m agent_guardrails.general.lint_pre_commit_hook_languages
         language: python
         types: [yaml]
         files: ^\.pre-commit-(?:config|hooks)\.yaml$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,27 +1,27 @@
 - id: lint-shell-portability
   name: Shell portability (no GNU-only syntax)
   language: python
-  entry: shell/lint_shell_portability.py
+  entry: python -m agent_guardrails.shell.lint_shell_portability
   types: [shell]
   exclude: '(^|/)(\.venv|node_modules|dist|build|mobile/android|frontend/dist)/'
 
 - id: lint-no-chinese
   name: No Chinese characters in source
   language: python
-  entry: general/lint_no_chinese.py
+  entry: python -m agent_guardrails.general.lint_no_chinese
   exclude: '(^|/)(\.venv|node_modules|dist|build|__pycache__|requirements)(/|$)|(^|/)(AGENTS|CLAUDE)\.md$'
 
 - id: lint-backend-bare-dict
   name: No bare dict in backend Python
   language: python
-  entry: python/lint_backend_bare_dict.py
+  entry: python -m agent_guardrails.python.lint_backend_bare_dict
   types: [python]
   exclude: '(^|/)(tests?|\.venv|__pycache__|dist|build)/'
 
 - id: lint-pre-commit-hook-languages
   name: Pre-commit hook language selection
   language: python
-  entry: general/lint_pre_commit_hook_languages.py
+  entry: python -m agent_guardrails.general.lint_pre_commit_hook_languages
   types: [yaml]
   files: ^\.pre-commit-(?:config|hooks)\.yaml$
   exclude: '^$'

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ AI coding agents write fast but ignore conventions. `agent-guardrails` enforces 
 
 A [pre-commit](https://pre-commit.com/) hook repository providing custom lints that no single-language tool covers — designed to work uniformly across multi-language, multi-repo setups.
 
+## CI
+
+GitHub Actions follows the same thin-wrapper pattern used by `pre-commit` and `pre-commit-hooks`: the workflow delegates execution to `tox`, and `tox` owns the repository validation contract.
+
+The test matrix checks the real consumer path with `pre-commit try-repo`, not just direct script execution. That catches packaging and entrypoint regressions before a release ships.
+
 ## Usage
 
 ### As pre-commit hooks
@@ -48,3 +54,10 @@ Repository-local skill:
 
 - use `.agents/skills/create-lint/` to create or migrate hooks in this repo
 - `.claude` is a symlink to `.agents`, so maintain the skill in `.agents` only
+
+Run the local validation matrix before opening a PR:
+
+```bash
+uv tool run tox -e py311
+uv tool run tox -e pre-commit
+```

--- a/agent_guardrails/__init__.py
+++ b/agent_guardrails/__init__.py
@@ -1,0 +1,1 @@
+"""Shared pre-commit hook implementations for agent-guardrails."""

--- a/agent_guardrails/general/__init__.py
+++ b/agent_guardrails/general/__init__.py
@@ -1,0 +1,1 @@
+"""General-purpose hook implementations."""

--- a/agent_guardrails/general/lint_no_chinese.py
+++ b/agent_guardrails/general/lint_no_chinese.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Lint rule: disallow Chinese characters in source code and UI files."""
 
 from __future__ import annotations
@@ -43,7 +42,7 @@ def scan_file(path: Path) -> list[str]:
 
 
 def main() -> int:
-    files = [Path(f) for f in sys.argv[1:]]
+    files = [Path(file_name) for file_name in sys.argv[1:]]
     if not files:
         return 0
 

--- a/agent_guardrails/general/lint_pre_commit_hook_languages.py
+++ b/agent_guardrails/general/lint_pre_commit_hook_languages.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Validate Python entrypoints in pre-commit YAML files use language: python."""
 
 from __future__ import annotations
@@ -11,6 +10,7 @@ from pathlib import Path
 HOOK_START_PATTERN = re.compile(r"^(?P<indent>\s*)- id:\s*(?P<hook_id>.+?)\s*$")
 FIELD_PATTERN = re.compile(r"^(?P<indent>\s+)(?P<key>entry|language):\s*(?P<value>.+?)\s*$")
 LIST_ITEM_PATTERN = re.compile(r"^(?P<indent>\s*)-\s")
+PYTHON_MODULE_ENTRY_PATTERN = re.compile(r"^python(?:\d+(?:\.\d+)?)?\s+-m\s+\S+")
 
 
 def normalize_scalar(raw_value: str) -> str:
@@ -19,6 +19,11 @@ def normalize_scalar(raw_value: str) -> str:
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
         return value[1:-1]
     return value
+
+
+def is_python_entrypoint(entry: str) -> bool:
+    """Return True when the hook entry executes Python code."""
+    return entry.endswith(".py") or PYTHON_MODULE_ENTRY_PATTERN.match(entry) is not None
 
 
 def check_file(path: Path) -> list[str]:
@@ -43,7 +48,7 @@ def check_file(path: Path) -> list[str]:
         nonlocal current_language
         nonlocal current_language_line
 
-        if current_hook_id is None or current_entry is None or not current_entry.endswith(".py"):
+        if current_hook_id is None or current_entry is None or not is_python_entrypoint(current_entry):
             current_hook_id = None
             current_hook_line = 0
             current_hook_indent = -1

--- a/agent_guardrails/python/__init__.py
+++ b/agent_guardrails/python/__init__.py
@@ -1,0 +1,1 @@
+"""Python-specific hook implementations."""

--- a/agent_guardrails/python/lint_backend_bare_dict.py
+++ b/agent_guardrails/python/lint_backend_bare_dict.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Lint rule: disallow bare dict literals in backend runtime code.
 
 Use structured models for protocol/API/storage payloads. Legitimate internal
@@ -258,7 +257,7 @@ def check_file(path: Path) -> list[str]:
 
 
 def main() -> int:
-    files = [Path(f) for f in sys.argv[1:]]
+    files = [Path(file_name) for file_name in sys.argv[1:]]
     if not files:
         return 0
 

--- a/agent_guardrails/shell/__init__.py
+++ b/agent_guardrails/shell/__init__.py
@@ -1,0 +1,1 @@
+"""Shell-specific hook implementations."""

--- a/agent_guardrails/shell/lint_shell_portability.py
+++ b/agent_guardrails/shell/lint_shell_portability.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Fail on known GNU-only shell syntax in repository scripts."""
 
 from __future__ import annotations
@@ -19,6 +18,7 @@ RULES: tuple[tuple[str, re.Pattern[str], str], ...] = (
 
 
 def check_file(path: Path) -> list[str]:
+    """Return portability violations for the given shell file."""
     violations: list[str] = []
     for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
         if ALLOW_COMMENT in line:
@@ -33,7 +33,7 @@ def check_file(path: Path) -> list[str]:
 
 
 def main() -> int:
-    files = [Path(f) for f in sys.argv[1:]]
+    files = [Path(file_name) for file_name in sys.argv[1:]]
     if not files:
         return 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,5 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 
-[tool.setuptools]
-packages = []
-py-modules = []
+[tool.setuptools.packages.find]
+include = ["agent_guardrails*"]

--- a/tests/test_hook_repository.py
+++ b/tests/test_hook_repository.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run(command: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+
+
+def _write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content).lstrip("\n"), encoding="utf-8")
+
+
+def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
+    return "\n".join(part for part in (result.stdout, result.stderr) if part).strip()
+
+
+@pytest.fixture(scope="session")
+def exported_hook_repo(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    exported_repo = tmp_path_factory.mktemp("exported-hook-repo")
+    shutil.copytree(
+        REPO_ROOT,
+        exported_repo,
+        dirs_exist_ok=True,
+        ignore=shutil.ignore_patterns(".git", ".tox", ".pytest_cache", "__pycache__"),
+    )
+    _init_git_repo(exported_repo)
+    subprocess.run(["git", "add", "-A", "--", "."], cwd=exported_repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-qm", "Export hook repo for try-repo tests"],
+        cwd=exported_repo,
+        check=True,
+    )
+    return exported_repo
+
+
+@pytest.fixture(scope="session")
+def pre_commit_home(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return tmp_path_factory.mktemp("pre-commit-home")
+
+
+def _run_try_repo(
+    *,
+    exported_hook_repo: Path,
+    pre_commit_home: Path,
+    tmp_path: Path,
+    hook_id: str,
+    files: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    _init_git_repo(tmp_path)
+    file_paths: list[str] = []
+    for relative_path, content in files.items():
+        target = tmp_path / relative_path
+        _write_file(target, content)
+        file_paths.append(relative_path)
+
+    subprocess.run(["git", "add", "--", *file_paths], cwd=tmp_path, check=True)
+
+    env = os.environ.copy()
+    env["PRE_COMMIT_HOME"] = str(pre_commit_home)
+    return _run(
+        ["pre-commit", "try-repo", str(exported_hook_repo), hook_id, "--files", *file_paths],
+        cwd=tmp_path,
+        env=env,
+    )
+
+
+def test_lint_no_chinese_validates_scope(
+    exported_hook_repo: Path,
+    pre_commit_home: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    failing_repo = tmp_path_factory.mktemp("lint-no-chinese-fail")
+    failing_result = _run_try_repo(
+        exported_hook_repo=exported_hook_repo,
+        pre_commit_home=pre_commit_home,
+        tmp_path=failing_repo,
+        hook_id="lint-no-chinese",
+        files={"src/app.py": 'print("\u4e2d\u6587")\n'},
+    )
+    assert failing_result.returncode == 1, _combined_output(failing_result)
+    assert "contains Chinese characters" in _combined_output(failing_result)
+
+    passing_repo = tmp_path_factory.mktemp("lint-no-chinese-pass")
+    passing_result = _run_try_repo(
+        exported_hook_repo=exported_hook_repo,
+        pre_commit_home=pre_commit_home,
+        tmp_path=passing_repo,
+        hook_id="lint-no-chinese",
+        files={"AGENTS.md": "\u4e2d\u6587\n"},
+    )
+    assert passing_result.returncode == 0, _combined_output(passing_result)
+
+
+def test_lint_shell_portability_validates_scope(
+    exported_hook_repo: Path,
+    pre_commit_home: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    failing_repo = tmp_path_factory.mktemp("lint-shell-portability-fail")
+    failing_result = _run_try_repo(
+        exported_hook_repo=exported_hook_repo,
+        pre_commit_home=pre_commit_home,
+        tmp_path=failing_repo,
+        hook_id="lint-shell-portability",
+        files={"scripts/build.sh": "sed -i 's/a/b/' file.txt\n"},
+    )
+    assert failing_result.returncode == 1, _combined_output(failing_result)
+    assert "SHP002" in _combined_output(failing_result)
+
+    passing_repo = tmp_path_factory.mktemp("lint-shell-portability-pass")
+    passing_result = _run_try_repo(
+        exported_hook_repo=exported_hook_repo,
+        pre_commit_home=pre_commit_home,
+        tmp_path=passing_repo,
+        hook_id="lint-shell-portability",
+        files={"frontend/dist/build.sh": "sed -i 's/a/b/' file.txt\n"},
+    )
+    assert passing_result.returncode == 0, _combined_output(passing_result)
+
+
+def test_lint_backend_bare_dict_validates_scope(
+    exported_hook_repo: Path,
+    pre_commit_home: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    failing_repo = tmp_path_factory.mktemp("lint-backend-bare-dict-fail")
+    failing_result = _run_try_repo(
+        exported_hook_repo=exported_hook_repo,
+        pre_commit_home=pre_commit_home,
+        tmp_path=failing_repo,
+        hook_id="lint-backend-bare-dict",
+        files={"app/service.py": 'payload = {"name": "demo"}\n'},
+    )
+    assert failing_result.returncode == 1, _combined_output(failing_result)
+    assert "bare dict literal is forbidden" in _combined_output(failing_result)
+
+    passing_repo = tmp_path_factory.mktemp("lint-backend-bare-dict-pass")
+    passing_result = _run_try_repo(
+        exported_hook_repo=exported_hook_repo,
+        pre_commit_home=pre_commit_home,
+        tmp_path=passing_repo,
+        hook_id="lint-backend-bare-dict",
+        files={"tests/test_service.py": 'payload = {"name": "demo"}\n'},
+    )
+    assert passing_result.returncode == 0, _combined_output(passing_result)
+
+
+def test_lint_pre_commit_hook_languages_validates_scope(
+    exported_hook_repo: Path,
+    pre_commit_home: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    failing_repo = tmp_path_factory.mktemp("lint-hook-language-fail")
+    failing_result = _run_try_repo(
+        exported_hook_repo=exported_hook_repo,
+        pre_commit_home=pre_commit_home,
+        tmp_path=failing_repo,
+        hook_id="lint-pre-commit-hook-languages",
+        files={
+            ".pre-commit-hooks.yaml": """
+                - id: bad-python-hook
+                  name: Bad Python hook
+                  entry: python -m tools.check
+                  language: script
+            """,
+        },
+    )
+    assert failing_result.returncode == 1, _combined_output(failing_result)
+    assert "language is 'script'" in _combined_output(failing_result)
+
+    passing_repo = tmp_path_factory.mktemp("lint-hook-language-pass")
+    passing_result = _run_try_repo(
+        exported_hook_repo=exported_hook_repo,
+        pre_commit_home=pre_commit_home,
+        tmp_path=passing_repo,
+        hook_id="lint-pre-commit-hook-languages",
+        files={
+            ".pre-commit-hooks.yaml": """
+                - id: shellcheck-wrapper
+                  name: Shell wrapper
+                  entry: shellcheck
+                  language: system
+            """,
+        },
+    )
+    assert passing_result.returncode == 0, _combined_output(passing_result)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = py311,py312,py313,pre-commit
+
+[testenv]
+deps =
+    pre-commit
+    pytest
+passenv =
+    HOME
+    PRE_COMMIT_HOME
+commands =
+    pytest
+
+[testenv:pre-commit]
+skip_install = true
+deps = pre-commit
+commands = pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
## Summary

- add a GitHub Actions workflow that delegates validation to `tox`
- package distributed Python hooks as installable modules while preserving the `general`, `python`, and `shell` split under `agent_guardrails`
- add `pre-commit try-repo` integration tests plus maintainer documentation for reproducing the CI path locally

## Testing

- `uv tool run tox -e py311`
- `uv tool run tox -e pre-commit`

close #5
