### PR TITLE
[ISSUE-19] Add lint-no-ignored-files pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,4 @@ repos:
       - id: lint-enum-redundant-string
       - id: uv-lock-check
       - id: lint-pre-commit-hook-languages
+      - id: lint-no-ignored-files

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -44,3 +44,8 @@
   types: [yaml]
   files: ^\.pre-commit-(?:config|hooks)\.yaml$
   exclude: '^$'
+
+- id: lint-no-ignored-files
+  name: No gitignored files in staging
+  language: python
+  entry: lint-no-ignored-files

--- a/agent_guardrails/general/lint_no_ignored_files.py
+++ b/agent_guardrails/general/lint_no_ignored_files.py
@@ -1,0 +1,47 @@
+"""Lint rule: prevent gitignored files from being committed."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def check_file(path: Path) -> list[str]:
+    """Return a violation if *path* matches a .gitignore rule."""
+    result = subprocess.run(
+        ["git", "check-ignore", "-v", "--no-index", "--", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    # exit 0 means the path IS ignored
+    if result.returncode == 0:
+        detail = result.stdout.strip()
+        return [f"{path}: matched by {detail}"]
+    return []
+
+
+def main() -> int:
+    files = [Path(f) for f in sys.argv[1:]]
+    if not files:
+        return 0
+
+    violations: list[str] = []
+    for path in files:
+        violations.extend(check_file(path))
+
+    if violations:
+        print("Ignored files must not be committed.")
+        print("Remove these paths from the Git index before continuing:")
+        for violation in violations:
+            print(f"  - {violation}")
+        print()
+        print("Suggested fix:")
+        print("  git rm --cached -- <path>")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ lint-enum-redundant-string = "agent_guardrails.python.lint_enum_redundant_string
 lint-file-line-count = "agent_guardrails.general.lint_file_line_count:main"
 lint-no-chinese = "agent_guardrails.general.lint_no_chinese:main"
 lint-pre-commit-hook-languages = "agent_guardrails.general.lint_pre_commit_hook_languages:main"
+lint-no-ignored-files = "agent_guardrails.general.lint_no_ignored_files:main"
 lint-shell-portability = "agent_guardrails.shell.lint_shell_portability:main"
 uv-lock-check = "agent_guardrails.python.uv_lock_check:main"
 

--- a/tests/test_hook_repository.py
+++ b/tests/test_hook_repository.py
@@ -260,6 +260,7 @@ def test_lint_file_line_count_validates_scope(
         ("lint-enum-redundant-string", "No redundant enum string literals"),
         ("lint-no-chinese", "No Chinese characters in source"),
         ("lint-file-line-count", "File line-count limit"),
+        ("lint-no-ignored-files", "No gitignored files in staging"),
         ("lint-pre-commit-hook-languages", "Pre-commit hook language selection"),
     ),
 )
@@ -294,6 +295,7 @@ def test_repository_self_check_config_runs_current_repo_hooks(
     assert "File line-count limit" in output
     assert "No bare dict in backend Python" in output
     assert "No redundant enum string literals" in output
+    assert "No gitignored files in staging" in output
     assert "Pre-commit hook language selection" in output
 
 
@@ -493,6 +495,45 @@ def test_lint_backend_bare_dict_validates_scope(
         tmp_path=passing_repo,
         hook_id="lint-backend-bare-dict",
         files={"tests/test_service.py": 'payload = {"name": "demo"}\n'},
+    )
+    assert passing_result.returncode == 0, _combined_output(passing_result)
+
+
+def test_lint_no_ignored_files_validates_scope(
+    exported_hook_repo: Path,
+    pre_commit_home: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    # Positive case: a gitignored file that is force-staged must fail.
+    failing_repo = tmp_path_factory.mktemp("lint-no-ignored-files-fail")
+    _init_git_repo(failing_repo)
+    _write_file(failing_repo / ".gitignore", "*.log\n")
+    subprocess.run(["git", "add", ".gitignore"], cwd=failing_repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "add gitignore"], cwd=failing_repo, check=True)
+    _write_file(failing_repo / "debug.log", "some log output\n")
+    subprocess.run(["git", "add", "-f", "debug.log"], cwd=failing_repo, check=True)
+
+    env = os.environ.copy()
+    env["PRE_COMMIT_HOME"] = str(pre_commit_home)
+    failing_result = _run(
+        [
+            "pre-commit", "try-repo", str(exported_hook_repo),
+            "lint-no-ignored-files", "--files", "debug.log",
+        ],
+        cwd=failing_repo,
+        env=env,
+    )
+    assert failing_result.returncode == 1, _combined_output(failing_result)
+    assert "Ignored files must not be committed" in _combined_output(failing_result)
+
+    # Negative case: a normal (non-ignored) file must pass.
+    passing_repo = tmp_path_factory.mktemp("lint-no-ignored-files-pass")
+    passing_result = _run_try_repo(
+        exported_hook_repo=exported_hook_repo,
+        pre_commit_home=pre_commit_home,
+        tmp_path=passing_repo,
+        hook_id="lint-no-ignored-files",
+        files={"src/main.py": "print('hello')\n"},
     )
     assert passing_result.returncode == 0, _combined_output(passing_result)
 


### PR DESCRIPTION
## Summary

- Add `lint-no-ignored-files` pre-commit hook that detects gitignored files staged for commit
- Prevents build artifacts, logs, and other ignored files from being accidentally committed via `git add -f`
- Reports which `.gitignore` rule matched and suggests `git rm --cached` fix

Close #19

## Test plan

- [x] Positive test: gitignored file force-staged -> hook fails with clear message
- [x] Negative test: normal file staged -> hook passes
- [x] Self-check: agent-guardrails repo passes the new hook
- [x] All 17 existing tests still pass
