### PR TITLE
[ISSUE-23] Batch git check-ignore into a single subprocess

### DIFF
--- a/agent_guardrails/general/lint_no_ignored_files.py
+++ b/agent_guardrails/general/lint_no_ignored_files.py
@@ -12,32 +12,45 @@ from __future__ import annotations
 
 import subprocess
 import sys
-from pathlib import Path
+
+# ``git check-ignore -z -v`` emits four NUL-separated fields per ignored path.
+_VERBOSE_FIELDS = 4
 
 
-def check_file(path: Path) -> list[str]:
-    """Return a violation if *path* matches a .gitignore rule."""
+def find_ignored(paths: list[str]) -> list[str]:
+    """Return a violation line for each path in *paths* matching a .gitignore rule.
+
+    All paths are passed to a single ``git check-ignore`` process. Spawning one
+    process per path instead makes this the dominant cost of a pre-commit run on
+    repositories with thousands of files.
+    """
+    if not paths:
+        return []
+
     result = subprocess.run(
-        ["git", "check-ignore", "-v", "--no-index", "--", str(path)],
+        ["git", "check-ignore", "-z", "-v", "--no-index", "--stdin"],
+        input="\0".join(paths) + "\0",
         capture_output=True,
         text=True,
     )
-    # exit 0 means the path IS ignored
-    if result.returncode == 0:
-        detail = result.stdout.strip()
-        return [f"{path}: matched by {detail}"]
-    return []
+    # Exit code 1 means no path was ignored; anything above that is a real
+    # failure (bad usage, not a repository, ...) that must not pass silently.
+    if result.returncode > 1:
+        message = result.stderr.strip() or "git check-ignore failed"
+        raise RuntimeError(f"{message} (exit code {result.returncode})")
+
+    fields = result.stdout.split("\0")
+    violations: list[str] = []
+    # The trailing NUL terminator leaves an empty final element; ignore any
+    # partial record rather than silently dropping half a violation.
+    for index in range(0, len(fields) - _VERBOSE_FIELDS + 1, _VERBOSE_FIELDS):
+        source, line, pattern, path = fields[index:index + _VERBOSE_FIELDS]
+        violations.append(f"{path}: matched by {source}:{line}:{pattern}\t{path}")
+    return violations
 
 
 def main() -> int:
-    files = [Path(f) for f in sys.argv[1:]]
-    if not files:
-        return 0
-
-    violations: list[str] = []
-    for path in files:
-        violations.extend(check_file(path))
-
+    violations = find_ignored(sys.argv[1:])
     if violations:
         print("Ignored files must not be committed.")
         print("Remove these paths from the Git index before continuing:")

--- a/tests/test_lint_no_ignored_files.py
+++ b/tests/test_lint_no_ignored_files.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent_guardrails.general.lint_no_ignored_files import find_ignored
+
+
+def _init_repo(root: Path, gitignore: str) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    (root / ".gitignore").write_text(gitignore, encoding="utf-8")
+
+
+@pytest.fixture()
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    _init_repo(tmp_path, "build/\n*.log\n")
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_returns_nothing_when_no_path_is_ignored(repo: Path) -> None:
+    assert find_ignored(["README.md", "src/main.py"]) == []
+
+
+def test_empty_input_skips_git_entirely(repo: Path) -> None:
+    assert find_ignored([]) == []
+
+
+def test_reports_the_matching_gitignore_rule(repo: Path) -> None:
+    violations = find_ignored(["build/out.o"])
+
+    assert len(violations) == 1
+    # The message must keep naming the rule source so `git rm --cached` guidance
+    # stays actionable.
+    assert violations[0].startswith("build/out.o: matched by .gitignore:1:build/")
+
+
+def test_reports_every_ignored_path_in_a_mixed_batch(repo: Path) -> None:
+    """A single batched call must not lose violations that follow clean paths."""
+    violations = find_ignored(["README.md", "build/out.o", "src/main.py", "debug.log"])
+
+    assert [v.split(":", 1)[0] for v in violations] == ["build/out.o", "debug.log"]
+
+
+def test_handles_paths_containing_spaces(repo: Path) -> None:
+    """NUL-delimited I/O keeps odd filenames from splitting into bogus records."""
+    violations = find_ignored(["my build/a.log", "README.md"])
+
+    assert len(violations) == 1
+    assert violations[0].startswith("my build/a.log: matched by ")
+
+
+def test_raises_when_git_cannot_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-repository must fail loudly rather than report zero violations."""
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(RuntimeError):
+        find_ignored(["README.md"])


### PR DESCRIPTION
Close #23

## 问题

`lint-no-ignored-files` 对每个待检查文件 fork 一次 `git check-ignore` 子进程，在文件数多的仓库上成为 pre-commit 全量运行的最大单项耗时。

## 改动

改用 `git check-ignore -z -v --stdin`，一次子进程处理全部路径。检查语义和覆盖率完全不变。

- `-z` NUL 分隔输入输出，避免文件名含空格/换行时被拆成错误记录
- 保留 `-v`，报错信息继续指出命中的 `.gitignore` 规则来源，`git rm --cached` 提示不降级

### 一个语义变化

批量模式下 `git check-ignore` 的 exit code 1 从「此文件未被忽略」变为「没有任何文件被忽略」。因此只有 `> 1` 才判定为 git 调用失败，且该情况**抛异常而非返回 0 violations** —— 否则 git 坏掉时会伪装成「检查通过」，属于静默降级。

## 验证

**性能与等价性**（下游仓库 `cp5_clearpage-restaurant-sites`，6542 个 tracked 文件）：

| 实现 | 耗时 |
|---|---|
| 旧（逐文件 fork） | 83.8s |
| 新（批量） | **0.5s** |

两者输出 **byte-for-byte 一致**（`diff` 为空）。另在含真实违规、且文件名带空格的仓库上单独比对，输出同样一致。

**回归测试**：新增 `tests/test_lint_no_ignored_files.py`，6 个用例覆盖无违规、空输入、规则来源、混合批次、空格文件名、非 git 仓库报错。

用反例验证过测试有区分能力（而非恒真）：

- 去掉 `returncode > 1` 守卫 → `test_raises_when_git_cannot_run` 失败
- 把 NUL 解析改成按行切分 → 混合批次与空格文件名用例失败
- 恢复实现 → 6 个全部通过

**全量**：`pytest` 33 passed；本仓 `pre-commit run --all-files` 全部 Passed。

## 影响范围

所有引用该 hook 的项目都会受益，文件数越多收益越大。下游需 bump `rev` 后生效。
